### PR TITLE
Use iteritems() to iterate over a dictionary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4] - in progress
+### Fixed
+- Fixed iteration over unmapped_with_mapped_mate dictionary.
+
 ## [1.3] - 2016-08-15
 ### Fixed
 - Fixed logging warnings when using Python 2.7

--- a/tophat-recondition.py
+++ b/tophat-recondition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/vagrant/local/share/bcbio/anaconda/bin/python
 # -*- coding: utf-8 -*
 #
 # Copyright (c) 2013-2016 Christian Brueffer (ORCID: 0000-0002-3826-0989)
@@ -205,7 +205,7 @@ def fix_unmapped_reads(path, outdir, mapped_file="accepted_hits.bam",
         # Reset unmapped reads with "mate is mapped" bit set, but where the
         # mapped mate is absent.  This works around TopHat issue #16
         # https://github.com/infphilo/tophat/issues/16
-        for readname, readidx in iter(unmapped_with_mapped_mate):
+        for readname, readidx in unmapped_with_mapped_mate.items():
             logger.info("Mapped mate not found, unpairing unmapped read: %s" % readname)
             unmapped_reads[readidx] = unpair_read(unmapped_reads[readidx])
             counters[FIX_UNPAIRED_READ] += 1


### PR DESCRIPTION
Hi Christian,

iter(dictionary) doesn't work:

```
>>> x = {"foo": "bar"}
>>> for k, v in iter(x):
...     print k, v
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: too many values to unpack
```

so I swapped this call with .iteritems() which should do the same thing.
